### PR TITLE
Persist auth and config SSH after start

### DIFF
--- a/gcp-tools/vm.sh
+++ b/gcp-tools/vm.sh
@@ -144,7 +144,7 @@ create-user-vm() {
 }
 
 start-vm() {
-  info "Starting VM $INSTANCE_NAME..."
+  info "Starting VM $INSTANCE_NAME and configuring SSH..."
   gcloud compute instances start "$INSTANCE_NAME" --zone="$ZONE" --project="$PROJECT_ID" || error_exit "Failed to start VM."
   gcloud compute config-ssh --project "$PROJECT_ID" || error_exit "Failed to configure SSH."
 }

--- a/gcp-tools/vm.sh
+++ b/gcp-tools/vm.sh
@@ -60,7 +60,7 @@ gcp-auth() {
     info "Authenticating for project $PROJECT_ID..."
     gcloud auth login \
       --project="$PROJECT_ID" \
-      --update-adc --force ||
+      --update-adc ||
       error_exit "Failed to authenticate gcloud."
   else
     info "Already authenticated for project $PROJECT_ID. Skipping authentication."
@@ -146,6 +146,7 @@ create-user-vm() {
 start-vm() {
   info "Starting VM $INSTANCE_NAME..."
   gcloud compute instances start "$INSTANCE_NAME" --zone="$ZONE" --project="$PROJECT_ID" || error_exit "Failed to start VM."
+  gcloud compute config-ssh --project "$PROJECT_ID" || error_exit "Failed to configure SSH."
 }
 
 stop-vm() {


### PR DESCRIPTION
`gcloud` auth now persists (instead of requiring re-authentication) and `vm.sh` now runs `config-ssh` after a VM starts (to configure the IP in `known_hosts`.